### PR TITLE
radarr: move to new library chart

### DIFF
--- a/media/radarr/Chart.yaml
+++ b/media/radarr/Chart.yaml
@@ -1,7 +1,7 @@
 name: radarr
 apiVersion: v2
-version: 1.0.0
+version: 2.0.0
 dependencies:
-- name: radarr
-  repository: https://k8s-at-home.com/charts
-  version: 16.3.2
+- name: common
+  version: 0.2.1
+  repository: https://bjw-s.github.io/helm-charts/

--- a/media/radarr/ci/ct-exportarr-values.yaml
+++ b/media/radarr/ci/ct-exportarr-values.yaml
@@ -1,0 +1,26 @@
+# Test exportarr
+persistence:
+  config:
+    enabled: true
+    type: emptyDir
+
+additionalContainers:
+  exportarr:
+    name: exportarr
+    image: ghcr.io/onedr0p/exportarr:v1.0.0
+    imagePullPolicy: IfNotPresent
+    args: ["radarr"]
+    env:
+    - name: PORT
+      value: "32123"
+    - name: URL
+      value: "http://localhost"
+    - name: CONFIG
+      value: "/config/config.xml"
+    ports:
+    - name: exportarr
+      containerPort: 32123
+    volumeMounts:
+    - name: config
+      mountPath: /config
+      readOnly: true

--- a/media/radarr/templates/common.yaml
+++ b/media/radarr/templates/common.yaml
@@ -1,0 +1,50 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the hardcoded settings */}}
+{{- define "radarr.harcodedValues" -}}
+{{ if .Values.metrics.enabled }}
+additionalContainers:
+  exporter:
+    name: exporter
+    image: "{{ .Values.metrics.exporter.image.repository }}:{{ .Values.metrics.exporter.image.tag }}"
+    imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy }}
+    args: ["radarr"]
+    env:
+      - name: URL
+        value: "http://localhost"
+      - name: CONFIG
+        value: "/config/config.xml"
+      - name: PORT
+        value: "{{ .Values.metrics.exporter.env.port }}"
+      - name: ENABLE_ADDITIONAL_METRICS
+        value: "{{ .Values.metrics.exporter.env.additionalMetrics }}"
+      - name: ENABLE_UNKNOWN_QUEUE_ITEMS
+        value: "{{ .Values.metrics.exporter.env.unknownQueueItems }}"
+    ports:
+      - name: metrics
+        containerPort: {{ .Values.metrics.exporter.env.port }}
+    volumeMounts:
+      {{ if .Values.persistence.config.enabled }}
+      - name: config
+        mountPath: /config
+        readOnly: true
+        {{ if .Values.persistence.config.subPath }}
+        subPath: {{ .Values.persistence.config.subPath }}
+        {{ end }}
+      {{ end }}
+
+service:
+  metrics:
+    enabled: true
+    ports:
+      metrics:
+        enabled: true
+        protocol: TCP
+        port: {{ .Values.metrics.exporter.env.port }}
+{{ end }}
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "radarr.harcodedValues" . | fromYaml) -}}
+
+{{/* Render the templates */}}
+{{ include "common.all" . }}

--- a/media/radarr/templates/prometheusrules.yaml
+++ b/media/radarr/templates/prometheusrules.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+{{- include "common.values.setup" . -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "common.names.fullname" . }}
+      rules:
+        - alert: ExportarrAbsent
+          annotations:
+            description: Radarr Exportarr has disappeared from Prometheus
+              service discovery.
+            summary: Exportarr is down.
+          expr: |
+            absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+        - alert: RadarrDown
+          annotations:
+            description: Radarr service is down.
+            summary: Radarr is down.
+          expr: |
+            radarr_system_status{job=~".*{{ include "common.names.fullname" . }}.*"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        {{- with .Values.metrics.prometheusRule.rules }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/media/radarr/templates/servicemonitor.yaml
+++ b/media/radarr/templates/servicemonitor.yaml
@@ -1,15 +1,26 @@
+{{- if .Values.metrics.enabled }}
+{{- include "common.values.setup" . -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
-      interval: 3m
-      scrapeTimeout: 1m
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
       path: /metrics
+{{- end }}

--- a/media/radarr/values.yaml
+++ b/media/radarr/values.yaml
@@ -1,52 +1,79 @@
-# https://github.com/k8s-at-home/library-charts/blob/main/charts/stable/common/values.yaml
-# https://github.com/k8s-at-home/charts/blob/master/charts/stable/radarr/values.yaml
-radarr:
-  image:
-    tag: v4.1.0.6175
+# https://github.com/bjw-s/helm-charts/tree/main/charts/library/common
+image:
+  repository: ghcr.io/onedr0p/radarr
+  tag: 4.2.4.6635
+  pullPolicy: IfNotPresent
 
-  env:
-    TZ: '{{ .Values.global.TZ }}' 
-  
-  ingress:
-    main:
-      enabled: true
-      ingressClassName: traefik
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production
-        traefik.ingress.kubernetes.io/router.entrypoints: websecure
-      hosts:
-      - host: '{{ .Chart.Name }}.{{ .Values.global.domain }}'
-        paths:
-        - path: /
-          pathType: Prefix      
-      tls:
-        - secretName: '{{ .Chart.Name }}-tls'
-          hosts:
-            - '{{ .Chart.Name }}.{{ .Values.global.domain }}'
+env:
+  TZ: '{{ .Values.global.TZ }}' 
 
-  persistence:
-    config:
-      enabled: true
-      storageClass: argo-zfspv-fast
-      size: 10Gi
-      accessMode: ReadWriteOnce
-      retain: true
-    media:
-      enabled: true
-      type: hostPath
-      hostPath: /mnt/andromeda/media
-      mountPath: /media
-    nzbdl:
-      enabled: true
-      type: hostPath
-      hostPath: /mnt/andromeda/media/nzbdl
-      mountPath: /nzbdl
+service:
+  main:
+    ports:
+      http:
+        port: 7878
 
-  podSecurityContext:
-    runAsUser: 1001
-    runAsGroup: 1002
-    fsGroup: 1002
-    fsGroupChangePolicy: OnRootMismatch
+ingress:
+  main:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-production
+      traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    hosts:
+    - host: '{{ .Chart.Name }}.{{ .Values.global.domain }}'
+      paths:
+      - path: /
+        pathType: Prefix      
+    tls:
+      - secretName: '{{ .Chart.Name }}-tls'
+        hosts:
+          - '{{ .Chart.Name }}.{{ .Values.global.domain }}'
+
+probes:
+  liveness:
+    enabled: true
+    ## Set this to true if you wish to specify your own livenessProbe
+    custom: true
+    ## The spec field contains the values for the default livenessProbe.
+    ## If you selected custom: true, this field holds the definition of the livenessProbe.
+    spec:
+      exec:
+        command:
+        - /usr/bin/env
+        - bash
+        - -c
+        - curl --fail localhost:7878/api/v3/system/status?apiKey=`IFS=\> && while
+          read -d \< E C; do if [[ $E = "ApiKey" ]]; then echo $C; fi; done < /config/config.xml`
+      failureThreshold: 5
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 10
+
+persistence:
+  config:
+    enabled: true
+    storageClass: argo-zfspv-fast
+    size: 10Gi
+    accessMode: ReadWriteOnce
+    retain: true
+  media:
+    enabled: true
+    type: hostPath
+    hostPath: /mnt/andromeda/media
+    mountPath: /media
+  nzbdl:
+    enabled: true
+    type: hostPath
+    hostPath: /mnt/andromeda/media/nzbdl
+    mountPath: /nzbdl
+
+podSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 1002
+  fsGroup: 1002
+  fsGroupChangePolicy: OnRootMismatch
 
 metrics:
   enabled: true


### PR DESCRIPTION
Well, Radarr, you were the first to squawk about needing an update - so this is the first thing we're trying post-k8s-at-home library chart deprecation. 

- move to bjw-s library chart (https://github.com/bjw-s/helm-charts/tree/main/charts/library/common)
- bring over existing "extras" specific to radarr from k8s-at-home
- also swap in new location for container image: https://github.com/onedr0p/containers